### PR TITLE
Fixes

### DIFF
--- a/scripts/generateDockerfile
+++ b/scripts/generateDockerfile
@@ -79,8 +79,9 @@ RUN apt-get autoremove -y
 
 # gcc & libc are needed for the 'cc' linker for Rust
 # clang and libclang are needed for building RocksDB
+# libssl-dev is needed for Substrate
 RUN $APT_INSTALL \
-  gcc libc-dev \
+  gcc libc-dev libssl-dev \
   clang libclang-dev && \
   cc --version && \
   clang --version


### PR DESCRIPTION
From https://github.com/paritytech/substrate/pull/9202#issuecomment-899439889

> Make sure you also have the development packages of openssl installed. For example, libssl-dev on Ubuntu or openssl-devel on Fedora.