### PR TITLE
Release mode is a more realistic environment to exec `try-runtime` 

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -227,6 +227,7 @@ export const getWebhooksHandlers = function (state: State) {
                 // polluted with a bunch of compilation stuff; bear in mind the
                 // output is posted on Github issues which have limited
                 // character count
+                "--release",
                 "--quiet",
                 "--features=try-runtime",
                 "try-runtime",


### PR DESCRIPTION
fixes #26 

I've done a full e2e test for adding this flag, can confirm the build takes longer but ..._that's the point_ :)

#### After

```
try-runtime-bot took 5 minutes, 57 seconds, 472 milliseconds (from 2021-11-11T02:16:43.021Z to 2021-11-11T02:22:40.493Z server time) for cargo run --release --quiet --features=try-runtime try-runtime --execution Native --no-spec-name-check on-runtime-upgrade live --uri ws://localhost:9944
```

#### Before
```
try-runtime-bot took 1 minutes, 52 seconds, 20 milliseconds (from 2021-11-11T02:53:55.348Z to 2021-11-11T02:55:47.368Z server time) for cargo run --quiet --features=try-runtime try-runtime --execution Native --no-spec-name-check on-runtime-upgrade live --uri ws://localhost:9944
```