### PR TITLE
Capture all output streams for try-runtime-cli

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -273,7 +273,7 @@ export const getWebhooksHandlers = function (state: State) {
                 requester,
                 execPath,
                 args,
-                env: command.env,
+                env: { ...command.env, CARGO_TERM_COLOR: "never" },
                 commentId,
                 installationId,
                 gitRef: { owner, repo, contributor, branch },


### PR DESCRIPTION
The problem of #42 might be due to us missing some output due to only capturing `stdout` but not `stderr`.

This PR implements capturing both `stdout` and `stderr` when we run the try-runtime-cli command.

might fix #42