### PR TITLE
command-bot

### DIFF
--- a/.env.example.cjs
+++ b/.env.example.cjs
@@ -43,7 +43,7 @@ process.env.GITLAB_PUSH_NAMESPACE ??= "placeholder"
   The default image to be used on GitLab jobs for bot commands which don't
   specify a custom image
 */
-process.env.GITLAB_DEFAULT_JOB_IMAGE ??= "placeholder"
+process.env.GITLAB_JOB_IMAGE ??= "placeholder"
 
 /*
   GITLAB_ACCESS_TOKEN token needs the following scopes:

--- a/.env.example.cjs
+++ b/.env.example.cjs
@@ -57,6 +57,15 @@ process.env.GITLAB_ACCESS_TOKEN ??= "placeholder"
 process.env.GITLAB_ACCESS_TOKEN_USERNAME ??= "placeholder"
 
 /*
+  Define a $PIPELINE_SCRIPTS_REPOSITORY (full URL to a Git repository, e.g.
+  "https://github.com/paritytech/pipeline-scripts") to be cloned on GitLab
+  pipelines with ref $PIPELINE_SCRIPTS_REF. Leave it unset to disable
+  $PIPELINE_SCRIPTS.
+*/
+// process.env.PIPELINE_SCRIPTS_REPOSITORY ??= "placeholder"
+// process.env.PIPELINE_SCRIPTS_REF ??= "placeholder"
+
+/*
   This private key's file can be generated and downloaded from
   https://github.com/settings/apps/[app-name].
   If you need to calculate the Base64 of the value manually, that can be done

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   DEPLOYMENT_TAG: ${CI_ENVIRONMENT_NAME}_${CI_COMMIT_TAG}
   DATA_PATH: /data
   PING_PORT: 3001
-  TASK_DB_VERSION: v2
+  TASK_DB_VERSION: v2.1
 
 default:
   image: $CI_IMAGE

--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ In `[bot-args]` you should provide the following options
     `cargo run --release --quiet --features=try-runtime try-runtime [args]`
 
 - `-v` / `--var` (optional): defines environment variables for the CI job which
-  runs the command. You can specify this option multiple times for multiple tags.
-  Note that you can also specify environment variables by putting them after
-  ` $ `, as showcased in the example below.
+  runs the command. You can specify this option multiple times for multiple
+  variables.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -41,18 +41,16 @@ command-bot executes arbitrary commands on GitLab CI from
 
 Comment in a pull request:
 
-`/cmd queue [bot-args] $ [command]`
+`/cmd queue [bot-args] $ [args]`
 
-In `[command]` you should provide a shell command to be run in the CI job. The
-`$ARTIFACTS_DIR` environment variable is available in case the command needs to
-generate some artifact.
+In `[bot-args]` you should provide the following options
 
-In `[bot-args]` you should provide the following arguments
-
-- `-t` / `--tag`: defines
-  [GitLab CI runner tags](https://docs.gitlab.com/ee/ci/runners/configure_runners.html#use-tags-to-control-which-jobs-a-runner-can-run)
-  which will be attached to the CI job for running the command. You can specify
-  this option multiple times for multiple tags.
+- `-c` / `--configuration`: select one of the following configurations
+  - `bench-bot`: runs
+    [`bench-bot`](https://github.com/paritytech/pipeline-scripts/blob/master/bench-bot.sh)
+    `[args]`
+  - `try-runtime`: runs
+    `cargo run --release --quiet --features=try-runtime try-runtime [args]`
 
 - `-v` / `--var`: defines environment variables for the CI job which runs the
   command. You can specify this option multiple times for multiple tags. Note
@@ -61,7 +59,7 @@ In `[bot-args]` you should provide the following arguments
 
 ### Example
 
-`/cmd queue -t linux-docker $ RUST_LOG=debug cargo run --quiet --features=foo bar`
+`/cmd queue -c bench-bot -v RUST_LOG=debug $ runtime westend-dev pallet_balances`
 
 ## Cancel <a name="pull-request-command-cancel"></a>
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In `[bot-args]` you should provide the following options
 
 ### Example
 
-`/cmd queue -c bench-bot -v RUST_LOG=debug $ runtime westend-dev pallet_balances`
+`/cmd queue -v RUST_LOG=debug -c bench-bot $ runtime westend-dev pallet_balances`
 
 ## Cancel <a name="pull-request-command-cancel"></a>
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ In `[bot-args]` you should provide the following options
   - `try-runtime`: runs
     `cargo run --release --quiet --features=try-runtime try-runtime [args]`
 
-- `-v` / `--var`: defines environment variables for the CI job which runs the
-  command. You can specify this option multiple times for multiple tags. Note
-  that you can also specify environment variables by putting them after ` $ `,
-  as showcased in the example below.
+- `-v` / `--var` (optional): defines environment variables for the CI job which
+  runs the command. You can specify this option multiple times for multiple tags.
+  Note that you can also specify environment variables by putting them after
+  ` $ `, as showcased in the example below.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ without having to go through pull request comments.
 
 ## Create a Personal Token <a name="api-create-token"></a>
 
-For interacting with the commands, first a Personal Token needs to be registered
+For interacting with the commands, first a Personal Token needs to be generated
 through `POST /api/access` by the
 [`$MASTER_TOKEN`](#setup-environment-variables) (it is currently owned
 by the OpsTooling team of Parity for Parity's deployments).
 
-Each Personal Token is tied to a Matrix Room ID where the command's output will
+Each Personal Token is tied to a Matrix Room ID where the command's outcome will
 be posted to after it finishes.
 
 ```
@@ -90,7 +90,6 @@ curl \
   -H "Content-Type: application/json" \
   -X POST http://command-bot/access \
   -d '{
-    "token": "secret",
     "matrixRoom": "!tZrvvMzoIkIYbCkLuk:matrix.foo.io",
   }'
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ In `[bot-args]` you should provide the following options
     [`bench-bot`](https://github.com/paritytech/pipeline-scripts/blob/master/bench-bot.sh)
     `[args]`
   - `try-runtime`: runs
-    `cargo run --release --quiet --features=try-runtime try-runtime [args]`
+    `cargo run --release --quiet --features=try-runtime try-runtime [args]`. Note
+    that you can use
+    [the dedicated internal RPC nodes](https://github.com/paritytech/devops/wiki/Internal-RPC-nodes)
+    in the arguments of this command.
 
 - `-v` / `--var` (optional): defines environment variables for the CI job which
   runs the command. You can specify this option multiple times for multiple

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Comment in a pull request:
 
 `/cmd queue [bot-args] $ [command]`
 
+In `[command]` you should provide a shell command to be run in the CI job. The
+`$ARTIFACTS_DIR` environment variable is available in case the command needs to
+generate some artifact.
+
 In `[bot-args]` you should provide the following arguments
 
 - `-t` / `--tag`: defines
@@ -50,9 +54,10 @@ In `[bot-args]` you should provide the following arguments
   which will be attached to the CI job for running the command. You can specify
   this option multiple times for multiple tags.
 
-In `[command]` you should provide a shell command to be run in the CI job. The
-`$ARTIFACTS_DIR` environment variable is available in case the command needs to
-generate some artifact.
+- `-v` / `--var`: defines environment variables for the CI job which runs the
+  command. You can specify this option multiple times for multiple tags. Note
+  that you can also specify environment variables by putting them after ` $ `,
+  as showcased in the example below.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ curl \
   -H "Accept: application/json" \
   -X POST http://command-bot/api/queue \
   -d '{
-    "job": {
-      "tags": ["linux-docker"],
-      "image": "paritytech/ci-linux:production"
+    "configuration": "bench-bot",
+    "args": ["runtime", "westend-dev", "pallet_balances"],
+    "variables": {
+      "RUST_LOG": "info"
     },
-    "command": "RUST_LOG=debug cargo run --features=foo bar",
     "gitRef": {
       "contributor": "paritytech",
       "owner": "paritytech",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -83,6 +83,7 @@ env:
   GITLAB_PUSH_NAMESPACE: parity/mirrors
   GITLAB_DEFAULT_JOB_IMAGE: paritytech/ci-linux:production
   GITLAB_DOMAIN: gitlab.parity.io
+  PIPELINE_SCRIPTS_REPOSITORY: https://github.com/paritytech/pipeline-scripts
 
 persistence:
   enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -81,7 +81,7 @@ tolerations:
 
 env:
   GITLAB_PUSH_NAMESPACE: parity/mirrors
-  GITLAB_DEFAULT_JOB_IMAGE: paritytech/ci-linux:production
+  GITLAB_JOB_IMAGE: paritytech/ci-linux:production
   GITLAB_DOMAIN: gitlab.parity.io
   PIPELINE_SCRIPTS_REPOSITORY: https://github.com/paritytech/pipeline-scripts
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "probot": "12.2.2",
     "stoppable": "1.1.0",
     "ts-node": "^10.7.0",
-    "yaml": "^2.0.1"
+    "yaml": "^2.0.1",
+    "yargs": "^17.5.0"
   },
   "devDependencies": {
     "@octokit/auth-app": "3.6.1",
@@ -37,6 +38,7 @@
     "@types/rocksdb": "3.0.1",
     "@types/shelljs": "0.8.11",
     "@types/stoppable": "1.1.1",
+    "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "5.19.0",
     "@typescript-eslint/parser": "5.19.0",
     "eslint": "8.13.0",

--- a/scripts/generateDockerfile
+++ b/scripts/generateDockerfile
@@ -98,7 +98,7 @@ RUN $APT_INSTALL \
 
 WORKDIR $APP_DIR
 
-RUN git config --global user.name "command-bot" && \
+RUN git config --global user.name command-bot && \
   git config --global user.email "<>"
 
 CMD . $CARGO_HOME/env && yarn start

--- a/scripts/generateDockerfile
+++ b/scripts/generateDockerfile
@@ -4,6 +4,7 @@ set -u
 
 PRE_COMMIT_BUILD_DEPS="gcc python3-dev libc-dev python3-pip"
 ROCKSDB_BUILD_DEPS="build-essential python3"
+SHFMT_BUILD_DEPS="wget ca-certificates"
 APT_INSTALL="apt install --assume-yes --quiet --no-install-recommends"
 APP_DIR="/app"
 NODE_USER="node"
@@ -54,7 +55,7 @@ RUN if [ ! "\$REPO" ]; then exit 1; fi
 $common
 
 # for downloading shfmt
-RUN $APT_INSTALL wget ca-certificates && apt-mark auto wget ca-certificates
+RUN $APT_INSTALL $SHFMT_BUILD_DEPS && apt-mark auto $SHFMT_BUILD_DEPS
 
 # shfmt is needed for shell command parsing
 RUN wget https://github.com/mvdan/sh/releases/download/v3.5.0/shfmt_v3.5.0_linux_amd64 -O /bin/shfmt && \
@@ -72,6 +73,7 @@ RUN mkdir $APP_DIR && \
   mv * $APP_DIR && \
   chown -R $NODE_USER:$NODE_USER $APP_DIR
 
+# clean up all build packages which are not needed to run the application
 RUN apt-get autoremove -y
 
 WORKDIR $APP_DIR

--- a/scripts/generateDockerfile
+++ b/scripts/generateDockerfile
@@ -58,26 +58,14 @@ RUN if [ ! "\$REPO" ]; then exit 1; fi
 
 $common
 
-# Rust is needed for running the bot's commands
-RUN $APT_INSTALL $RUST_BUILD_DEPS && apt-mark auto $RUST_BUILD_DEPS
-ENV RUSTUP_HOME=$RUSTUP_HOME \
-  CARGO_HOME=$CARGO_HOME \
-  PATH=$CARGO_HOME/bin:\$PATH
-RUN curl https://sh.rustup.rs -sSf | sh -s -- \
-    -y \
-    --no-modify-path \
-    --default-host $SUBSTRATE_HOST \
-    --profile minimal && \
-  . $CARGO_HOME/env && \
-  cargo --version && rustup --version && \
-  rustup toolchain install stable-$SUBSTRATE_HOST && \
-  rustup toolchain install nightly-$SUBSTRATE_HOST && \
-  rustup target add wasm32-unknown-unknown --toolchain nightly
+# for downloading shfmt
+RUN $APT_INSTALL wget ca-certificates && apt-mark auto wget ca-certificates
 
 # shfmt is needed for shell command parsing
 RUN wget https://github.com/mvdan/sh/releases/download/v3.5.0/shfmt_v3.5.0_linux_amd64 -O /bin/shfmt && \
   echo "8feea043364a725dfb69665432aee9e85b84c7f801a70668650e8b15452f6574  /bin/shfmt" | sha256sum --check && \
-  chmod +x /bin/shfmt
+  chmod +x /bin/shfmt && \
+  shfmt --version
 
 # Needed for building RocksDB bindings for Node.js
 RUN $APT_INSTALL $ROCKSDB_BUILD_DEPS && apt-mark auto $ROCKSDB_BUILD_DEPS
@@ -90,16 +78,6 @@ RUN mkdir $APP_DIR && \
   chown -R $NODE_USER:$NODE_USER $APP_DIR
 
 RUN apt-get autoremove -y
-
-# The following packages are needed to Substrate-based projects at runtime due
-# to C/C++ dependencies e.g. jemalloc, RocksDB, etc.
-RUN $APT_INSTALL \
-  gcc libc-dev libssl-dev libudev-dev pkg-config build-essential clang libclang-dev && \
-  cc --version && \
-  gcc --version && \
-  g++ --version && \
-  make --version && \
-  clang --version
 
 WORKDIR $APP_DIR
 

--- a/scripts/generateDockerfile
+++ b/scripts/generateDockerfile
@@ -74,6 +74,11 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- \
   rustup toolchain install nightly-$SUBSTRATE_HOST && \
   rustup target add wasm32-unknown-unknown --toolchain nightly
 
+# shfmt is needed for shell command parsing
+RUN wget https://github.com/mvdan/sh/releases/download/v3.5.0/shfmt_v3.5.0_linux_amd64 -O /bin/shfmt && \
+  echo "8feea043364a725dfb69665432aee9e85b84c7f801a70668650e8b15452f6574  /bin/shfmt" | sha256sum --check && \
+  chmod +x /bin/shfmt
+
 # Needed for building RocksDB bindings for Node.js
 RUN $APT_INSTALL $ROCKSDB_BUILD_DEPS && apt-mark auto $ROCKSDB_BUILD_DEPS
 

--- a/scripts/generateDockerfile
+++ b/scripts/generateDockerfile
@@ -84,7 +84,7 @@ WORKDIR $APP_DIR
 RUN git config --global user.name command-bot && \
   git config --global user.email "<>"
 
-CMD . $CARGO_HOME/env && yarn start
+CMD yarn start
 EOF
     echo "$app"
     ;;

--- a/scripts/generateDockerfile
+++ b/scripts/generateDockerfile
@@ -2,13 +2,8 @@
 
 set -u
 
-RUSTUP_HOME=/usr/local/rustup
-CARGO_HOME=/usr/local/cargo
 PRE_COMMIT_BUILD_DEPS="gcc python3-dev libc-dev python3-pip"
-RUST_BUILD_DEPS="curl ca-certificates"
 ROCKSDB_BUILD_DEPS="build-essential python3"
-# https://github.com/paritytech/substrate/search?q=x86_64-unknown-linux-gnu
-SUBSTRATE_HOST=x86_64-unknown-linux-gnu
 APT_INSTALL="apt install --assume-yes --quiet --no-install-recommends"
 APP_DIR="/app"
 NODE_USER="node"

--- a/src/api.ts
+++ b/src/api.ts
@@ -184,7 +184,7 @@ export const setupApi = (ctx: Context, server: Server) => {
 
     const cancelError = await cancelTask(ctx, taskId)
     if (cancelError instanceof LevelErrors.NotFoundError) {
-      return errorResponse(res, next, 422, "Task not found")
+      return errorResponse(res, next, 404)
     }
 
     response(res, next, 204)

--- a/src/api.ts
+++ b/src/api.ts
@@ -206,7 +206,7 @@ export const setupApi = (ctx: Context, server: Server) => {
       gitlab: {
         job: {
           ...configuration.gitlab.job,
-          variables: variables ?? {},
+          variables: { ...configuration.gitlab.job.variables, ...variables },
           image: gitlab.jobImage,
         },
         pipeline: null,

--- a/src/api.ts
+++ b/src/api.ts
@@ -160,7 +160,7 @@ export const setupApi = (ctx: Context, server: Server) => {
     } = req.body as Pick<ApiTask, "gitRef"> & {
       configuration: string
       args: string[]
-      variables: Record<string, number | boolean | string>
+      variables?: Record<string, number | boolean | string>
     }
 
     const configuration =
@@ -204,7 +204,11 @@ export const setupApi = (ctx: Context, server: Server) => {
       requester: matrixRoom,
       command,
       gitlab: {
-        job: { ...configuration.gitlab.job, variables, image: gitlab.jobImage },
+        job: {
+          ...configuration.gitlab.job,
+          variables: variables ?? {},
+          image: gitlab.jobImage,
+        },
         pipeline: null,
       },
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,6 +21,10 @@ const getApiRoute = (route: string) => {
 
 const taskRoute = "/task/:task_id"
 
+export const getApiTaskEndpoint = (task: ApiTask) => {
+  return getApiRoute(taskRoute).replaceAll(":task_id", task.id)
+}
+
 const response = <T>(
   res: Response,
   next: NextFunction,
@@ -168,12 +172,7 @@ export const setupApi = (ctx: Context, server: Server) => {
       updateProgress,
     })
 
-    response(res, next, 201, {
-      task,
-      message: `${queueMessage} Send a DELETE request to ${getApiRoute(
-        taskRoute,
-      )} for cancelling`,
-    })
+    response(res, next, 201, { task, queueMessage })
   })
 
   setupRoute("delete", taskRoute, async ({ req, res, next }) => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -22,17 +22,22 @@ import {
 import { Context, PullRequestError } from "./types"
 import { displayError, getLines } from "./utils"
 
+export const botPullRequestCommentMention = "/cmd"
+export const botPullRequestCommentSubcommands: {
+  [K in "queue" | "cancel"]: K
+} = { queue: "queue", cancel: "cancel" }
+
 type ParsedBotCommand = {
   jobTags: string[]
   command: string
-  subCommand: "queue" | "cancel"
+  subCommand: keyof typeof botPullRequestCommentSubcommands
   variables: Record<string, string>
 }
 const parsePullRequestBotCommandLine = (rawCommandLine: string) => {
   let commandLine = rawCommandLine.trim()
 
-  const botPullRequestCommentMention = "/cmd "
-  if (!commandLine.startsWith(botPullRequestCommentMention)) {
+  // Add trailing whitespace so that /cmd can be differentiated from /cmd-[?]
+  if (!commandLine.startsWith(`${botPullRequestCommentMention} `)) {
     return
   }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -238,6 +238,7 @@ const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = async (
     }
 
     for (const parsedCommand of commands) {
+      logger.info(parsedCommand, "Processing parsed command")
       switch (parsedCommand.subCommand) {
         case "queue": {
           const installationId = installation?.id
@@ -334,7 +335,7 @@ const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = async (
           break
         }
         case "cancel": {
-          const cancelledTasks: { id: string; commentId?: number }[] = []
+          const cancelledTasks: PullRequestTask[] = []
 
           for (const { task } of await getSortedTasks(ctx)) {
             if (task.tag !== "PullRequestTask") {
@@ -362,12 +363,12 @@ const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = async (
           }
 
           for (const cancelledTask of cancelledTasks) {
-            if (cancelledTask.commentId === undefined) {
+            if (cancelledTask.comment.id === undefined) {
               continue
             }
             await updateComment(ctx, octokit, {
               ...commentParams,
-              comment_id: cancelledTask.commentId,
+              comment_id: cancelledTask.comment.id,
               body: `@${requester} command was cancelled`.trim(),
             })
           }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -22,17 +22,16 @@ import {
 import { Context, PullRequestError } from "./types"
 import { displayError, getLines } from "./utils"
 
-export const botPullRequestCommentMention = "/cmd"
-
 type ParsedBotCommand = {
   jobTags: string[]
   command: string
   subCommand: "queue" | "cancel"
   variables: Record<string, string>
 }
-export const parsePullRequestBotCommandLine = (rawCommandLine: string) => {
+const parsePullRequestBotCommandLine = (rawCommandLine: string) => {
   let commandLine = rawCommandLine.trim()
 
+  const botPullRequestCommentMention = "/cmd"
   if (!commandLine.startsWith(botPullRequestCommentMention)) {
     return
   }
@@ -117,7 +116,7 @@ export const parsePullRequestBotCommandLine = (rawCommandLine: string) => {
       )
       if ((jobTags?.length ?? 0) === 0) {
         return new Error(
-          `No job tags were parsed from the command line ${rawCommandLine}`,
+          `No job tags were parsed from the command line "${rawCommandLine}"`,
         )
       }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -350,7 +350,7 @@ const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = async (
             queuedDate: serializeTaskQueuedDate(queuedDate),
             gitlab: {
               job: {
-                tags: parsedCommand.configuration.gitlab.job.tags,
+                ...parsedCommand.configuration.gitlab.job,
                 image: gitlab.jobImage,
                 variables: parsedCommand.variables,
               },

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -64,17 +64,19 @@ export const parsePullRequestBotCommandLine = (rawCommandLine: string) => {
 
   switch (subCommand) {
     case "queue": {
-      const startOfArgs = " $ "
-      const indexOfArgsStart = commandLine.indexOf(startOfArgs)
-      if (indexOfArgsStart === -1) {
-        return new Error(`Could not find start of arguments ("${startOfArgs}")`)
+      const commandStartSymbol = " $ "
+      const indexOfCommandStart = commandLine.indexOf(commandStartSymbol)
+      if (indexOfCommandStart === -1) {
+        return new Error(
+          `Could not find start of command ("${commandStartSymbol}")`,
+        )
       }
 
       const commandLinePart = commandLine.slice(
-        indexOfArgsStart + startOfArgs.length,
+        indexOfCommandStart + commandStartSymbol.length,
       )
 
-      const botOptionsLinePart = commandLine.slice(0, indexOfArgsStart)
+      const botOptionsLinePart = commandLine.slice(0, indexOfCommandStart)
       const botOptionsTokens = botOptionsLinePart.split(" ").filter((value) => {
         botOptionsLinePart
         return !!value

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -371,7 +371,11 @@ const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = async (
               await updateComment(ctx, octokit, {
                 ...commentParams,
                 comment_id: cancelledTask.comment.id,
-                body: `@${requester} command was cancelled`.trim(),
+                body: `@${requester} \`${cancelledTask.command}\`${
+                  cancelledTask.gitlab.pipeline === null
+                    ? ""
+                    : ` (${cancelledTask.gitlab.pipeline.jobWebUrl})`
+                } was cancelled in ${comment.html_url}`,
               })
             } catch (error) {
               logger.error(

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -344,7 +344,10 @@ const onIssueCommentCreated: WebhookHandler<"issue_comment.created"> = async (
               job: {
                 ...parsedCommand.configuration.gitlab.job,
                 image: gitlab.jobImage,
-                variables: parsedCommand.variables,
+                variables: {
+                  ...parsedCommand.configuration.gitlab.job.variables,
+                  ...parsedCommand.variables,
+                },
               },
               pipeline: null,
             },

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -31,7 +31,7 @@ type ParsedBotCommand = {
 const parsePullRequestBotCommandLine = (rawCommandLine: string) => {
   let commandLine = rawCommandLine.trim()
 
-  const botPullRequestCommentMention = "/cmd"
+  const botPullRequestCommentMention = "/cmd "
   if (!commandLine.startsWith(botPullRequestCommentMention)) {
     return
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -40,7 +40,7 @@ export const commandsConfiguration: {
   },
   "bench-bot": {
     gitlab: { job: { tags: ["weights"] } },
-    commandStart: ["$PIPELINE_SCRIPTS_DIR/bench-bot.sh"],
+    commandStart: ['"$PIPELINE_SCRIPTS_DIR/bench-bot.sh"'],
   },
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -30,8 +30,7 @@ export const commandsConfiguration: {
       "--release",
       /*
         "--quiet" should be kept so that the output doesn't get polluted
-        with a bunch of compilation stuff; bear in mind the output is posted
-        on Github comments which have limited character count
+        with a bunch of compilation stuff
       */
       "--quiet",
       "--features=try-runtime",

--- a/src/core.ts
+++ b/src/core.ts
@@ -72,16 +72,12 @@ export const prepareBranch = async function* (
 ) {
   const { token, url } = await getFetchEndpoint()
 
-  const cmdRunner = new CommandRunner(ctx, {
-    itemsToRedact: [token],
-    shouldTrackProgress: false,
-  })
+  const cmdRunner = new CommandRunner(ctx, { itemsToRedact: [token] })
 
   yield cmdRunner.run("mkdir", ["-p", repoPath])
 
   const repoCmdRunner = new CommandRunner(ctx, {
     itemsToRedact: [token],
-    shouldTrackProgress: false,
     cwd: repoPath,
   })
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -11,6 +11,7 @@ export type CommandConfiguration = {
   gitlab: {
     job: {
       tags: string[]
+      variables: Record<string, string>
     }
   }
   commandStart: string[]
@@ -19,7 +20,12 @@ export const commandsConfiguration: {
   [K in "try-runtime" | "bench-bot"]: CommandConfiguration
 } = {
   "try-runtime": {
-    gitlab: { job: { tags: ["linux-docker"] } },
+    gitlab: {
+      job: {
+        tags: ["linux-docker"],
+        variables: { RUST_LOG: "remote-ext=info" },
+      },
+    },
     commandStart: [
       "cargo",
       "run",
@@ -38,7 +44,7 @@ export const commandsConfiguration: {
     ],
   },
   "bench-bot": {
-    gitlab: { job: { tags: ["weights"] } },
+    gitlab: { job: { tags: ["weights"], variables: {} } },
     commandStart: ['"$PIPELINE_SCRIPTS_DIR/bench-bot.sh"'],
   },
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -3,6 +3,10 @@ import { CommandRunner } from "./shell"
 import { Task } from "./task"
 import { Context } from "./types"
 
+/*
+  TODO: Move command configurations to configuration repository or database so
+  that it can be updated dynamically, without redeploying the application
+*/
 export type CommandConfiguration = {
   gitlab: {
     job: {

--- a/src/core.ts
+++ b/src/core.ts
@@ -3,6 +3,43 @@ import { CommandRunner } from "./shell"
 import { Task } from "./task"
 import { Context } from "./types"
 
+export type CommandConfiguration = {
+  gitlab: {
+    job: {
+      tags: string[]
+    }
+  }
+  commandStart: string[]
+}
+export const commandsConfiguration: {
+  [K in "try-runtime" | "bench-bot"]: CommandConfiguration
+} = {
+  "try-runtime": {
+    gitlab: { job: { tags: ["linux-docker"] } },
+    commandStart: [
+      "cargo",
+      "run",
+      /*
+        Requirement: always run the command in release mode.
+        See https://github.com/paritytech/try-runtime-bot/issues/26#issue-1049555966
+      */
+      "--release",
+      /*
+        "--quiet" should be kept so that the output doesn't get polluted
+        with a bunch of compilation stuff; bear in mind the output is posted
+        on Github comments which have limited character count
+      */
+      "--quiet",
+      "--features=try-runtime",
+      "try-runtime",
+    ],
+  },
+  "bench-bot": {
+    gitlab: { job: { tags: ["weights"] } },
+    commandStart: ["$PIPELINE_SCRIPTS_DIR/bench-bot.sh"],
+  },
+}
+
 export const isRequesterAllowed = async (
   ctx: Context,
   octokit: ExtendedOctokit,

--- a/src/github.ts
+++ b/src/github.ts
@@ -297,10 +297,11 @@ export const getPostPullRequestResult = (
         owner,
         repo,
         issue_number: prNumber,
-        body: `@${requester} Command \`${command}\` has finished. Result:\n\`\`\`\n
-        ${
-          typeof result === "string" ? result : displayError(result)
-        }\n\`\`\`\n`,
+        body: `@${requester} Command \`${command}\` has finished. Result: ${
+          typeof result === "string"
+            ? result
+            : `\n\`\`\`\n${displayError(result)}\n\`\`\`\n`
+        }`,
       })
     } catch (error) {
       logger.error(

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -83,14 +83,11 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
     `https://token:${gitlab.accessToken}@${gitlab.domain}/${gitlabProjectPath}.git`,
   ])
 
-  await cmdRunner.run("git", [
-    "push",
-    "--force",
-    "-o",
-    "ci.skip",
-    gitlabRemote,
-    "HEAD",
-  ])
+  /*
+    It's not necessary to say "--option ci.skip" because the pipeline execution
+    is conditional per workflow:rules
+  */
+  await cmdRunner.run("git", ["push", "--force", gitlabRemote, "HEAD"])
 
   const pipeline = await validatedFetch<{
     id: number

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -19,7 +19,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
     withRef: boolean
   }) => {
     return `git clone --depth 1 ${
-      withRef ? `--branch="$PIPELINE_SCRIPTS_REF"` : ""
+      withRef ? `--branch "$PIPELINE_SCRIPTS_REF"` : ""
     } "$PIPELINE_SCRIPTS_REPOSITORY" "$PIPELINE_SCRIPTS_DIR"`
   }
 

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -24,7 +24,8 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
   */
   const headSha = await cmdRunner.run("git", ["rev-parse", "HEAD"])
 
-  const pipelineScriptsDir = ".git/.pipeline-scripts"
+  const artifactsFolderPath = ".git/.artifacts"
+
   const getPipelineScriptsCloneCommand = ({
     withRef,
   }: {
@@ -35,7 +36,6 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
     } "$PIPELINE_SCRIPTS_REPOSITORY" "$PIPELINE_SCRIPTS_DIR"`
   }
 
-  const artifactsFolderPath = ".git/.command-bot-artifacts"
   await fsWriteFile(
     path.join(task.repoPath, ".gitlab-ci.yml"),
     yaml.stringify({
@@ -67,6 +67,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
           paths: [artifactsFolderPath],
         },
         variables: {
+          ...task.gitlab.job.variables,
           GH_CONTRIBUTOR: task.gitRef.contributor,
           GH_CONTRIBUTOR_REPO: task.gitRef.repo,
           GH_CONTRIBUTOR_BRANCH: task.gitRef.branch,
@@ -74,8 +75,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
           COMMIT_MESSAGE: task.command,
           PIPELINE_SCRIPTS_REPOSITORY: ctx.pipelineScripts?.repository,
           PIPELINE_SCRIPTS_REF: ctx.pipelineScripts?.ref,
-          PIPELINE_SCRIPTS_DIR: pipelineScriptsDir,
-          ...task.gitlab.job.variables,
+          PIPELINE_SCRIPTS_DIR: ".git/.scripts",
         },
       },
     }),

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -210,17 +210,6 @@ export const restoreTaskGitlabContext = async (ctx: Context, task: Task) => {
   return getAliveTaskGitlabContext(ctx, pipeline)
 }
 
-export const isPipelineFinishedStatus = (status: string) => {
-  switch (status) {
-    case "success":
-    case "skipped":
-    case "canceled":
-    case "failed": {
-      return true
-    }
-  }
-}
-
 const getAliveTaskGitlabContext = (
   ctx: Context,
   pipeline: TaskGitlabPipeline,

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -37,12 +37,12 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
         ...task.gitlab.job,
         script: [
           // prettier-ignore
-          'if [ "${PIPELINE_SCRIPTS_REPOSITORY:-}" ]; then' +
-            'if [ "${PIPELINE_SCRIPTS_REF:-}" ]; then' +
-              getPipelineScriptsCloneCommand({ withRef: true }) + ';' +
+          'if [ "${PIPELINE_SCRIPTS_REPOSITORY:-}" ]; then ' +
+            'if [ "${PIPELINE_SCRIPTS_REF:-}" ]; then ' +
+              getPipelineScriptsCloneCommand({ withRef: true }) + "; " +
             "else" +
-              getPipelineScriptsCloneCommand({ withRef: false }) + ';' +
-            "fi" + ';' +
+              getPipelineScriptsCloneCommand({ withRef: false }) + "; " +
+            "fi" + "; " +
           "fi",
           `export ARTIFACTS_DIR="$PWD/${artifactsFolderPath}"`,
           `mkdir -p "$ARTIFACTS_DIR"`,

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -167,7 +167,6 @@ export const cancelGitlabPipeline = async (
   await validatedFetch(
     fetch(
       /*
-        https://docs.gitlab.com/ee/api/pipelines.html#cancel-a-pipelines-jobs
         Note: this endpoint can be called any time, even if the pipeline has
         already finished
       */

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -33,7 +33,6 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
         ],
         artifacts: {
           name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}",
-          when: "on_success",
           expire_in: "7 days",
           paths: [artifactsFolderName],
         },

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -9,8 +9,6 @@ import { Task, taskExecutionTerminationEvent, TaskGitlabPipeline } from "./task"
 import { Context } from "./types"
 import { validatedFetch } from "./utils"
 
-const runCommandBranchPrefix = "ci-exec"
-
 export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
   const { logger } = ctx
 
@@ -54,7 +52,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
     cwd: task.repoPath,
   })
 
-  const branchName = `${runCommandBranchPrefix}/${
+  const branchName = `cmd-bot/${
     "prNumber" in task.gitRef ? task.gitRef.prNumber : task.gitRef.branch
   }`
   await cmdRunner.run("git", ["branch", "-D", branchName], {

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -170,10 +170,12 @@ export const cancelGitlabPipeline = async (
         Note: this endpoint can be called any time, even if the pipeline has
         already finished
       */
-      `https://${gitlab.domain}/api/v4/projects/${pipeline.projectId}/pipeline/${pipeline.id}/cancel`,
+      `https://${gitlab.domain}/api/v4/projects/${pipeline.projectId}/pipelines/${pipeline.id}/cancel`,
       { method: "POST", headers: { "PRIVATE-TOKEN": gitlab.accessToken } },
     ),
-    Joi.object().keys({ id: Joi.number() }).options({ allowUnknown: true }),
+    Joi.object()
+      .keys({ id: Joi.number().required() })
+      .options({ allowUnknown: true }),
   )
 }
 

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -20,6 +20,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
     yaml.stringify({
       command: {
         ...task.gitlab.job,
+        workflow: { rules: [{ if: `$CI_PIPELINE_SOURCE == "api"` }] },
         script: [
           `export ARTIFACTS_DIR="$PWD/${artifactsFolderName}"`,
           `mkdir -p "$ARTIFACTS_DIR"`,

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -20,7 +20,12 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
     yaml.stringify({
       command: {
         ...task.gitlab.job,
-        workflow: { rules: [{ if: `$CI_PIPELINE_SOURCE == "api"` }] },
+        workflow: {
+          rules: [
+            { if: `$CI_PIPELINE_SOURCE == "api"` },
+            { if: `$CI_PIPELINE_SOURCE == "web"` },
+          ],
+        },
         script: [
           `export ARTIFACTS_DIR="$PWD/${artifactsFolderName}"`,
           `mkdir -p "$ARTIFACTS_DIR"`,

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -40,7 +40,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
           'if [ "${PIPELINE_SCRIPTS_REPOSITORY:-}" ]; then ' +
             'if [ "${PIPELINE_SCRIPTS_REF:-}" ]; then ' +
               getPipelineScriptsCloneCommand({ withRef: true }) + "; " +
-            "else" +
+            "else " +
               getPipelineScriptsCloneCommand({ withRef: false }) + "; " +
             "fi" + "; " +
           "fi",

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -150,7 +150,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
       .length(1)
       .required(),
   )
-  logger.info(job, `Created job for task ${task.id}`)
+  logger.info(job, `Fetched job for task ${task.id}`)
 
   return getAliveTaskGitlabContext(ctx, {
     id: pipeline.id,

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -1,10 +1,11 @@
 import EventEmitter from "events"
+import { writeFile } from "fs/promises"
 import Joi from "joi"
 import fetch from "node-fetch"
 import path from "path"
 import yaml from "yaml"
 
-import { CommandRunner, fsWriteFile } from "./shell"
+import { CommandRunner } from "./shell"
 import { Task, taskExecutionTerminationEvent, TaskGitlabPipeline } from "./task"
 import { Context } from "./types"
 import { validatedFetch } from "./utils"
@@ -36,7 +37,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
     } "$PIPELINE_SCRIPTS_REPOSITORY" "$PIPELINE_SCRIPTS_DIR"`
   }
 
-  await fsWriteFile(
+  await writeFile(
     path.join(task.repoPath, ".gitlab-ci.yml"),
     yaml.stringify({
       workflow: {

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -14,7 +14,7 @@ const runCommandBranchPrefix = "ci-exec"
 export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
   const { logger } = ctx
 
-  const artifactsFolderName = ".command-bot-artifacts"
+  const artifactsFolderPath = ".git/.command-bot-artifacts"
   await fsWriteFile(
     path.join(task.repoPath, ".gitlab-ci.yml"),
     yaml.stringify({
@@ -27,14 +27,14 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
           ],
         },
         script: [
-          `export ARTIFACTS_DIR="$PWD/${artifactsFolderName}"`,
+          `export ARTIFACTS_DIR="$PWD/${artifactsFolderPath}"`,
           `mkdir -p "$ARTIFACTS_DIR"`,
           task.command,
         ],
         artifacts: {
           name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}",
           expire_in: "7 days",
-          paths: [artifactsFolderName],
+          paths: [artifactsFolderPath],
         },
         variables: {
           GH_CONTRIBUTOR: task.gitRef.contributor,

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -22,6 +22,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
         ...task.gitlab.job,
         script: [
           `export ARTIFACTS_DIR="$PWD/${artifactsFolderName}"`,
+          `mkdir -p "$ARTIFACTS_DIR"`,
           task.command,
         ],
         artifacts: {

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -36,11 +36,14 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
       command: {
         ...task.gitlab.job,
         script: [
-          `if [ "\${PIPELINE_SCRIPTS_REPOSITORY:-}" ]; then if [ "\${PIPELINE_SCRIPTS_REF:-}" ]; then ${getPipelineScriptsCloneCommand(
-            { withRef: true },
-          )}; else ${getPipelineScriptsCloneCommand({
-            withRef: false,
-          })}; fi; fi`,
+          // prettier-ignore
+          'if [ "${PIPELINE_SCRIPTS_REPOSITORY:-}" ]; then' +
+            'if [ "${PIPELINE_SCRIPTS_REF:-}" ]; then' +
+              getPipelineScriptsCloneCommand({ withRef: true }) + ';' +
+            "else" +
+              getPipelineScriptsCloneCommand({ withRef: false }) + ';' +
+            "fi" + ';' +
+          "fi",
           `export ARTIFACTS_DIR="$PWD/${artifactsFolderPath}"`,
           `mkdir -p "$ARTIFACTS_DIR"`,
           task.command,

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -18,14 +18,14 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
   await fsWriteFile(
     path.join(task.repoPath, ".gitlab-ci.yml"),
     yaml.stringify({
+      workflow: {
+        rules: [
+          { if: `$CI_PIPELINE_SOURCE == "api"` },
+          { if: `$CI_PIPELINE_SOURCE == "web"` },
+        ],
+      },
       command: {
         ...task.gitlab.job,
-        workflow: {
-          rules: [
-            { if: `$CI_PIPELINE_SOURCE == "api"` },
-            { if: `$CI_PIPELINE_SOURCE == "web"` },
-          ],
-        },
         script: [
           `export ARTIFACTS_DIR="$PWD/${artifactsFolderPath}"`,
           `mkdir -p "$ARTIFACTS_DIR"`,

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -160,9 +160,10 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
 }
 
 export const cancelGitlabPipeline = async (
-  { gitlab }: Context,
-  { id, projectId }: { id: number; projectId: number },
+  { gitlab, logger }: Context,
+  pipeline: TaskGitlabPipeline,
 ) => {
+  logger.info(pipeline, "Cancelling GitLab pipeline")
   await validatedFetch(
     fetch(
       /*
@@ -170,7 +171,7 @@ export const cancelGitlabPipeline = async (
         Note: this endpoint can be called any time, even if the pipeline has
         already finished
       */
-      `https://${gitlab.domain}/api/v4/projects/${projectId}/pipeline/${id}/cancel`,
+      `https://${gitlab.domain}/api/v4/projects/${pipeline.projectId}/pipeline/${pipeline.id}/cancel`,
       { method: "POST", headers: { "PRIVATE-TOKEN": gitlab.accessToken } },
     ),
     Joi.object().keys({ id: Joi.number() }).options({ allowUnknown: true }),

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -34,6 +34,7 @@ export const runCommandInGitlabPipeline = async (ctx: Context, task: Task) => {
         artifacts: {
           name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}",
           expire_in: "7 days",
+          when: "always",
           paths: [artifactsFolderPath],
         },
         variables: {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -82,7 +82,7 @@ export class Logger {
             level,
             name: this.options.name,
             context: this.options.context,
-            msg: normalizeValue(item),
+            msg: normalizeValue(item, [], true),
             description,
             extra,
           }),
@@ -99,7 +99,7 @@ export class Logger {
             ? []
             : ["~@ Context:", normalizedContext]),
           ...(extra.length === 0 ? [] : ["~@ Extra:", normalizeValue(extra)]),
-          normalizeValue(item),
+          normalizeValue(item, [], true),
         )
         break
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import assert from "assert"
+import { readFile, writeFile } from "fs/promises"
 import http from "http"
 import path from "path"
 import { Logger as ProbotLogger, Probot, Server } from "probot"
@@ -7,7 +8,7 @@ import stoppable from "stoppable"
 
 import { Logger } from "./logger"
 import { setup } from "./setup"
-import { ensureDir, fsReadFile, fsWriteFile } from "./shell"
+import { ensureDir } from "./shell"
 import { envNumberVar, envVar } from "./utils"
 
 const main = async () => {
@@ -76,7 +77,7 @@ const main = async () => {
     ? await (async (appDbVersion) => {
         const currentDbVersion = await (async () => {
           try {
-            return (await fsReadFile(appDbVersionPath)).toString().trim()
+            return (await readFile(appDbVersionPath)).toString().trim()
           } catch (error) {
             if (
               /*
@@ -96,7 +97,7 @@ const main = async () => {
           }
         })()
         if (currentDbVersion !== appDbVersion) {
-          await fsWriteFile(appDbVersionPath, appDbVersion)
+          await writeFile(appDbVersionPath, appDbVersion)
           return true
         }
       })(process.env.TASK_DB_VERSION.trim())

--- a/src/main.ts
+++ b/src/main.ts
@@ -174,6 +174,16 @@ const main = async () => {
   const gitlabPushNamespace = envVar("GITLAB_PUSH_NAMESPACE")
   const gitlabDefaultJobImage = envVar("GITLAB_DEFAULT_JOB_IMAGE")
 
+  const pipelineScripts = (() => {
+    const pipelineScriptsRepository = process.env.PIPELINE_SCRIPTS_REPOSITORY
+    if (pipelineScriptsRepository) {
+      return {
+        repository: pipelineScriptsRepository,
+        ref: process.env.PIPELINE_SCRIPTS_REF,
+      }
+    }
+  })()
+
   await server.load((probot) => {
     void setup(probot, server, {
       appId,
@@ -189,6 +199,7 @@ const main = async () => {
       masterToken,
       shouldClearTaskDatabaseOnStart,
       isDeployment: !!process.env.IS_DEPLOYMENT,
+      pipelineScripts,
       gitlab: {
         accessToken: gitlabAccessToken,
         accessTokenUsername: gitlabAccessTokenUsername,

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ const main = async () => {
     }
   })()
   const logger = new Logger({
-    name: "try-runtime-bot",
+    name: "command-bot",
     minLogLevel,
     logFormat,
     impl: console,

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,7 +188,7 @@ const main = async () => {
   const gitlabAccessTokenUsername = envVar("GITLAB_ACCESS_TOKEN_USERNAME")
   const gitlabDomain = envVar("GITLAB_DOMAIN")
   const gitlabPushNamespace = envVar("GITLAB_PUSH_NAMESPACE")
-  const gitlabDefaultJobImage = envVar("GITLAB_DEFAULT_JOB_IMAGE")
+  const gitlabJobImage = envVar("GITLAB_JOB_IMAGE")
 
   const pipelineScripts = (() => {
     const pipelineScriptsRepository = process.env.PIPELINE_SCRIPTS_REPOSITORY
@@ -221,7 +221,7 @@ const main = async () => {
         accessTokenUsername: gitlabAccessTokenUsername,
         domain: gitlabDomain,
         pushNamespace: gitlabPushNamespace,
-        defaultJobImage: gitlabDefaultJobImage,
+        jobImage: gitlabJobImage,
       },
     })
   })

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -34,6 +34,7 @@ export const setup = async (
     | "allowedOrganizations"
     | "masterToken"
     | "gitlab"
+    | "pipelineScripts"
   > & {
     appId: number
     clientId: string

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -58,9 +58,12 @@ export const setup = async (
 
   const taskDbPath = await initDatabaseDir(path.join(dataPath, "db"))
   const taskDb = new TaskDB(getDb(taskDbPath))
+  const tasks = await getSortedTasks({ taskDb, logger })
+  logger.info(tasks, "Tasks found at the start of the application")
+
   if (shouldClearTaskDatabaseOnStart) {
     logger.info("Clearing the task database during setup")
-    for (const { id } of await getSortedTasks({ taskDb, logger })) {
+    for (const { id } of tasks) {
       await taskDb.db.del(id)
     }
   }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -174,7 +174,9 @@ export const validateSingleShellCommand = async (
     commandAst.Stmts.length !== 1 ||
     commandAst.Stmts[0].Cmd.Type !== "CallExpr"
   ) {
-    return new Error(`Command "${command}" failed validation`)
+    return new Error(
+      `Command "${command}" failed validation: the resulting command line should have a single command`,
+    )
   }
   return command
 }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -30,7 +30,7 @@ export class CommandRunner {
     ctx: Context,
     private configuration: {
       itemsToRedact: string[]
-      shouldTrackProgress: boolean
+      shouldTrackProgress?: boolean
       cwd?: string
       onChild?: (child: ChildProcess) => void
     },
@@ -156,10 +156,7 @@ export const validateSingleShellCommand = async (
   command: string,
 ) => {
   const { logger } = ctx
-  const cmdRunner = new CommandRunner(ctx, {
-    itemsToRedact: [],
-    shouldTrackProgress: false,
-  })
+  const cmdRunner = new CommandRunner(ctx, { itemsToRedact: [] })
   const commandAstText = await cmdRunner.run("shfmt", ["--tojson"], {
     stdinInput: command,
   })

--- a/src/task.ts
+++ b/src/task.ts
@@ -232,7 +232,7 @@ export const queueTask = async (
           afterTaskRun(
             `${taskPipeline.jobWebUrl} ${
               taskIsAlive ? "finished" : "was cancelled"
-            }`,
+            }.`,
           )
         })
         .catch(afterTaskRun)

--- a/src/task.ts
+++ b/src/task.ts
@@ -43,6 +43,7 @@ type TaskBase<T> = {
     job: {
       tags: string[]
       image: string
+      variables: Record<string, string>
     }
     pipeline: TaskGitlabPipeline | null
   }

--- a/src/task.ts
+++ b/src/task.ts
@@ -232,7 +232,9 @@ export const queueTask = async (
           afterTaskRun(
             `${taskPipeline.jobWebUrl} has ${
               taskIsAlive ? "finished" : "was cancelled"
-            }.`,
+            }. If any artifacts were generated, you can download them from ${
+              taskPipeline.jobWebUrl
+            }/artifacts/download.`,
           )
         })
         .catch(afterTaskRun)

--- a/src/task.ts
+++ b/src/task.ts
@@ -416,6 +416,7 @@ export const getSendTaskMatrixResult = (
 export const cancelTask = async (ctx: Context, taskId: Task | string) => {
   const {
     taskDb: { db },
+    logger,
   } = ctx
 
   const task =
@@ -435,6 +436,8 @@ export const cancelTask = async (ctx: Context, taskId: Task | string) => {
   if (task instanceof Error) {
     return task
   }
+
+  logger.info(task, "Cancelling task")
 
   if (task.gitlab.pipeline !== null) {
     await cancelGitlabPipeline(ctx, task.gitlab.pipeline)

--- a/src/task.ts
+++ b/src/task.ts
@@ -206,7 +206,7 @@ export const queueTask = async (
 
         if (updateProgress) {
           await updateProgress(
-            `@${task.requester} ${pipelineCtx.jobWebUrl} was started. Check out https://${gitlab.domain}/${gitlab.pushNamespace}/${task.gitRef.repo}/-/pipelines?page=1&scope=all&username=${gitlab.accessTokenUsername} to know what else is being executed currently.`,
+            `@${task.requester} ${pipelineCtx.jobWebUrl} was started for your command \`${task.command}\`. Check out https://${gitlab.domain}/${gitlab.pushNamespace}/${task.gitRef.repo}/-/pipelines?page=1&scope=all&username=${gitlab.accessTokenUsername} to know what else is being executed currently.`,
           )
         }
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -156,7 +156,7 @@ export const queueTask = async (
   const additionalTaskCancelInstructions = (() => {
     switch (task.tag) {
       case "PullRequestTask": {
-        return `\n\nComment \`/${botPullRequestCommentMention} ${botPullRequestCommentSubcommands.cancel}\` to cancel all commands for this pull request.`
+        return `\n\nComment \`${botPullRequestCommentMention} ${botPullRequestCommentSubcommands.cancel}\` to cancel all commands for this pull request.`
       }
       case "ApiTask": {
         return `Send a DELETE request to ${getApiTaskEndpoint(

--- a/src/task.ts
+++ b/src/task.ts
@@ -48,7 +48,7 @@ type TaskBase<T> = {
     job: {
       tags: string[]
       image: string
-      variables: Record<string, string>
+      variables: Record<string, string | boolean | number>
     }
     pipeline: TaskGitlabPipeline | null
   }

--- a/src/task.ts
+++ b/src/task.ts
@@ -156,7 +156,7 @@ export const queueTask = async (
   const additionalTaskCancelInstructions = (() => {
     switch (task.tag) {
       case "PullRequestTask": {
-        return `\n\nComment \`${botPullRequestCommentMention} ${botPullRequestCommentSubcommands.cancel}\` to cancel all commands for this pull request.`
+        return `\n\nComment \`${botPullRequestCommentMention} ${botPullRequestCommentSubcommands.cancel} ${task.id}\` to cancel this command or \`${botPullRequestCommentMention} ${botPullRequestCommentSubcommands.cancel}\` to cancel all commands in this pull request.`
       }
       case "ApiTask": {
         return `Send a DELETE request to ${getApiTaskEndpoint(

--- a/src/task.ts
+++ b/src/task.ts
@@ -300,6 +300,8 @@ export const requeueUnterminatedTasks = async (ctx: Context, bot: Probot) => {
                   Assumes the relevant progress update was already sent when
                   the task was queued for the first time, thus there's no need
                   to keep updating it
+                  TODO: Update the item in the database to tell when
+                  updateProgress no longer needs to be called.
                 */
                 updateProgress: null,
               })
@@ -339,6 +341,8 @@ export const requeueUnterminatedTasks = async (ctx: Context, bot: Probot) => {
                     Assumes the relevant progress update was already sent when
                     the task was queued for the first time, thus there's no need
                     to keep updating it
+                    TODO: Update the item in the database to tell when
+                    updateProgress no longer needs to be called.
                   */
                   updateProgress: null,
                 })

--- a/src/task.ts
+++ b/src/task.ts
@@ -230,7 +230,7 @@ export const queueTask = async (
         .waitUntilFinished(taskEventChannel)
         .then(() => {
           afterTaskRun(
-            `${taskPipeline.jobWebUrl} ${
+            `${taskPipeline.jobWebUrl} has ${
               taskIsAlive ? "finished" : "was cancelled"
             }.`,
           )

--- a/src/task.ts
+++ b/src/task.ts
@@ -432,7 +432,6 @@ export const cancelTask = async (ctx: Context, taskId: Task | string) => {
           }
         })()
       : taskId
-
   if (task instanceof Error) {
     return task
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export type Context = {
     accessToken: string
     domain: string
     pushNamespace: string
-    defaultJobImage: string
+    jobImage: string
     accessTokenUsername: string
   }
   pipelineScripts:

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,12 @@ export type Context = {
     defaultJobImage: string
     accessTokenUsername: string
   }
+  pipelineScripts:
+    | {
+        repository: string
+        ref: string | undefined
+      }
+    | undefined
 }
 
 export class PullRequestError {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -213,3 +213,13 @@ export const validatedFetch = async <T>(
   }
   return validation.value as T
 }
+
+export const arrayify = (value: unknown) => {
+  if (value === undefined || value === null) {
+    return []
+  }
+  if (Array.isArray(value)) {
+    return value
+  }
+  return [value]
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,15 +69,6 @@ export const displayError = (value: unknown) => {
   return errorMessage
 }
 
-export const escapeHtml = (str: string) => {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;")
-}
-
 let lastIncrementalId = 0
 export const getNextUniqueIncrementalId = () => {
   const nextIncrementalId = ++lastIncrementalId

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,7 +120,11 @@ const normalizers = {
   string: (value: any) => {
     return value
   },
-  object: (value: any, previousObjects: unknown[] = []) => {
+  object: (
+    value: any,
+    previousObjects: unknown[] = [],
+    showTopLevel = false,
+  ) => {
     if (value === null) {
       return
     }
@@ -161,6 +165,8 @@ const normalizers = {
 
     if (Object.keys(output).length > 0) {
       return container
+    } else if (showTopLevel) {
+      return objAsArray ? [] : {}
     }
   },
 }
@@ -186,9 +192,11 @@ const setNormalizedKeyValue = (
 export const normalizeValue = (
   value: unknown,
   previousObjects: unknown[] = [],
+  showTopLevel = false,
 ): unknown => {
-  return normalizers[typeof value](value, previousObjects)
+  return normalizers[typeof value](value, previousObjects, showTopLevel)
 }
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
 
 export const validatedFetch = async <T>(
   response: ReturnType<typeof fetch>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,6 +887,18 @@
     "@types/configstore" "*"
     boxen "^4.2.0"
 
+"@types/yargs-parser@*":
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
+  integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
+
+"@types/yargs@^17.0.10":
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.10.tgz#591522fce85d8739bca7b8bb90d048e4478d186a"
+  integrity sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@typescript-eslint/eslint-plugin@5.19.0":
   version "5.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz#9608a4b6d0427104bccf132f058cba629a6553c0"
@@ -1416,6 +1428,15 @@ cli-boxes@^2.2.0, cli-boxes@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-response@^1.0.2:
   version "1.0.2"
@@ -2333,6 +2354,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
@@ -4069,6 +4095,11 @@ request@^2.88.2:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -4349,7 +4380,7 @@ stoppable@1.1.0:
   resolved "https://registry.yarnpkg.com/stoppable/-/stoppable-1.1.0.tgz#32da568e83ea488b08e4d7ea2c3bcc9d75015d5b"
   integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.2:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4814,6 +4845,11 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
@@ -4823,6 +4859,24 @@ yaml@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.1.tgz#71886d6021f3da28169dbefde78d4dd0f8d83650"
   integrity sha512-1NpAYQ3wjzIlMs0mgdBmYzLkFgWBIWrzYVDYfrixhoFNNgJ444/jT2kUT2sicRbJES3oQYRZugjB6Ro8SjKeFg==
+
+yargs-parser@^21.0.0:
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
+  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
+
+yargs@^17.5.0:
+  version "17.5.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.0.tgz#2706c5431f8c119002a2b106fc9f58b9bb9097a3"
+  integrity sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
This PR refactors the code base in order to enable the execution arbitrary commands through GitLab CI instead of having the bot be hardcoded to executing the try-runtime-cli directly in the host. In-depth motivation for this design was given in https://github.com/paritytech/opstooling/issues/105.

Example usage is given at https://github.com/paritytech/polkadot/pull/5478#issuecomment-1120435275.

After this PR is deployed we should rebrand this repository as `command-bot` and update the external documentation, such as https://gitlab.parity.io/groups/parity/opstooling/-/wikis, to reflect the new name.

closes https://github.com/paritytech/opstooling/issues/105
related to https://github.com/paritytech/devops/issues/1589
blocked by https://github.com/paritytech/devops/issues/1631 for try-runtime-bot's use-case
closes #24
closes #14

# TODO

- [x] Test it more
- [x] Comment it more
- [x] Verify feasibility of feature-parity with bench-bot
  - https://github.com/paritytech/polkadot/pull/5478/commits/68f6d4787c60fe047097f314eb4e1d65121cec35
  - https://github.com/paritytech/polkadot/pull/5478#issuecomment-1120435282